### PR TITLE
Browser version to try visbeat easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ Project Website: http://abedavis.com/visualbeat/
 You can install using 
 `pip install visbeat`
 
+Try it in the browser [here](https://colab.research.google.com/drive/1VGobRIKoFW8Old2dgzkWFx6ft2ASreh1?usp=sharing), using Google Colab version developed by [Mathias Gatti](http://mathigatti.com/).
+
 The easiest way to get started is probably to use the docker file. It will install everything and run a jupyter notebook for you in the examples folder. If you have trouble getting things to run on your own machine, the docker file may also provide guidance.
- 


### PR DESCRIPTION
Just added a link to a free online notebook (google colab) where you can install and run the package just following the instructions.